### PR TITLE
fix: SPサイズの時のnavの色が残る不具合修正

### DIFF
--- a/frontend/src/app/(app)/_component/bottomNav/BottomNavItem.tsx
+++ b/frontend/src/app/(app)/_component/bottomNav/BottomNavItem.tsx
@@ -19,7 +19,7 @@ type BottomNavItemProps<T extends string> = {
 const textColor = tv({
   base: `
   group flex flex-1 flex-col items-center justify-center gap-1 pl-3 py-2 rounded-lg
-  hover:bg-tomato-4
+  sm:hover:bg-tomato-4
   sm:flex-row sm:justify-start sm:gap-2 sm:pr-5 sm:rounded-full `,
   variants: {
     isActive: {


### PR DESCRIPTION
## タスク URL

#36 

# 作業内容

- SPサイズの時にnavをタップするとback-groundの色がついてしまっいた部分を修正

## 作業内容補足（任意）

- 作業内容の補足説明があればここに記載

## なぜやるのか（任意）

- タスクで説明できない捕捉的な事項 (タスク以上の説明が無ければ不要)
- なぜこのプルリクエストが必要と考えたかについて説明があるとレビュワーがわかりやすい

# 使い方や動作確認

- 使い方
- 再現手順（どの環境でどんな動作チェックをしたか）
- 動作確認をした事についてスクショなどがあるとわかりやすくて良い

## Image


### PC


### SP

https://github.com/qin-team-recipe/05-recipe-app/assets/71167689/0f5bbace-7b59-4ee9-b9eb-0f7765f146c7


# レビューにあたって参考にすべき情報（任意）

- 悩んでいること
- とくにレビューしてほしいところ

## 備考（任意）

- その他伝えたいこと
