### PR TITLE
[レシピ詳細]ヒーロ部分をシェフ詳細のヒーローコンポーネントから条件で出し分ける

### DIFF
--- a/frontend/src/app/(app)/_component/backButton/BackButton.tsx
+++ b/frontend/src/app/(app)/_component/backButton/BackButton.tsx
@@ -5,6 +5,7 @@ import { useRouter } from "next/navigation"
 
 import { IconArrowLeft } from "@tabler/icons-react"
 
+/** @package */
 export const BackButton = () => {
   const router = useRouter()
 

--- a/frontend/src/app/(app)/_component/backButton/index.ts
+++ b/frontend/src/app/(app)/_component/backButton/index.ts
@@ -1,0 +1,1 @@
+export { BackButton } from "./BackButton"

--- a/frontend/src/app/(app)/_component/header/PageDetailHeader.tsx
+++ b/frontend/src/app/(app)/_component/header/PageDetailHeader.tsx
@@ -1,5 +1,6 @@
 import React, { FC } from "react"
 import Image from "next/image"
+import Link from "next/link"
 
 import { ContentContainer } from "@/app/(app)/_component/container"
 import { BackButton, ChefFavButton } from "@/app/(app)/chef/[chefId]/_component"
@@ -56,16 +57,16 @@ export const PageDetailHeader: FC<DetailHeroProps<"chef" | "recipe">> = (
               </div>
             </div>
           ) : (
-            <div className="align-center text-mauve-dim flex gap-2 text-sm">
-              <div className="align-center flex gap-1">
-                <div className="round-full w-12">{data.userImg}</div>
+            <div className="align-center text-mauve-normal flex gap-2 text-sm">
+              <Link className="align-center flex gap-1" href="/">
+                <div className="aspect-square w-6 rounded-full bg-gray-7"></div>
                 <div>{data.user}</div>
-              </div>
+              </Link>
               <div>
                 <span className="text-mauve-normal pr-1 font-bold">
                   {data.favoriteCount}
                 </span>
-                フォロワー
+                お気に入り
               </div>
             </div>
           )}

--- a/frontend/src/app/(app)/_component/header/PageDetailHeader.tsx
+++ b/frontend/src/app/(app)/_component/header/PageDetailHeader.tsx
@@ -2,8 +2,9 @@ import React, { FC } from "react"
 import Image from "next/image"
 import Link from "next/link"
 
+import { BackButton } from "@/app/(app)/_component/backButton"
 import { ContentContainer } from "@/app/(app)/_component/container"
-import { BackButton, ChefFavButton } from "@/app/(app)/chef/[chefId]/_component"
+import { FollowButton } from "@/app/(app)/chef/[chefId]/_component"
 
 type Common = {
   img: string
@@ -71,7 +72,7 @@ export const PageDetailHeader: FC<DetailHeroProps<"chef" | "recipe">> = (
             </div>
           )}
         </div>
-        <ChefFavButton />
+        <FollowButton pageType={pageType} />
       </ContentContainer>
     </div>
   )

--- a/frontend/src/app/(app)/_component/header/PageDetailHeader.tsx
+++ b/frontend/src/app/(app)/_component/header/PageDetailHeader.tsx
@@ -4,28 +4,71 @@ import Image from "next/image"
 import { ContentContainer } from "@/app/(app)/_component/container"
 import { BackButton, ChefFavButton } from "@/app/(app)/chef/[chefId]/_component"
 
+type Common = {
+  img: string
+  introduction: string
+  name: string
+}
+
+type Chef = {
+  follower: number
+  recipeCount: number
+} & Common
+
+type Recipe = {
+  favoriteCount: number
+  user: string
+  userImg: string
+} & Common
+
+type DetailHeroProps<T extends "chef" | "recipe"> = T extends "chef"
+  ? { data: Chef; pageType: T }
+  : { data: Recipe; pageType: T }
+
 /** @package */
-export const PageDetailHeader: FC = () => {
+export const PageDetailHeader: FC<DetailHeroProps<"chef" | "recipe">> = (
+  props,
+) => {
+  const { data, pageType } = props
   return (
     <div>
-      <div className="relative h-96 max-h-screen w-full">
-        <Image src="/chef.jpg" alt="chef" fill className="h-3/4 object-cover" />
+      <div className="relative aspect-square max-h-screen w-full">
+        <Image src={data.img} alt={data.name} fill className="object-cover" />
         <BackButton />
       </div>
       <ContentContainer>
         <div className="text-mauve-normal">
-          <h1 className="pt-4 text-2xl font-bold">山田シェフ</h1>
-          <div className="py-4">
-            初の絵本出版！『まねっこシェフ』・ふわふわ！スクランブルエッグ・にぎにぎ！おにぎり主婦の友社より３月３日、２冊同時発売！絶賛発売中！
-          </div>
-          <div className="align-center text-mauve-dim flex gap-2 text-sm">
-            <div>
-              <span className="text-mauve-normal pr-1 font-bold">2,345</span>
-              レシピ
-              <span className="text-mauve-normal pr-1 font-bold">1,234</span>
-              フォロワー
+          <h1 className="pt-4 text-2xl font-bold">{data.name}</h1>
+          <div className="py-4">{data.introduction}</div>
+          {pageType == "chef" ? (
+            <div className="align-center text-mauve-dim flex gap-2 text-sm">
+              <div>
+                <span className="text-mauve-normal pr-1 font-bold">
+                  {data.recipeCount}
+                </span>
+                レシピ
+              </div>
+              <div>
+                <span className="text-mauve-normal pr-1 font-bold">
+                  {data.follower}
+                </span>
+                フォロワー
+              </div>
             </div>
-          </div>
+          ) : (
+            <div className="align-center text-mauve-dim flex gap-2 text-sm">
+              <div className="align-center flex gap-1">
+                <div className="round-full w-12">{data.userImg}</div>
+                <div>{data.user}</div>
+              </div>
+              <div>
+                <span className="text-mauve-normal pr-1 font-bold">
+                  {data.favoriteCount}
+                </span>
+                フォロワー
+              </div>
+            </div>
+          )}
         </div>
         <ChefFavButton />
       </ContentContainer>

--- a/frontend/src/app/(app)/chef/[chefId]/_component/FollowButton.tsx
+++ b/frontend/src/app/(app)/chef/[chefId]/_component/FollowButton.tsx
@@ -14,8 +14,13 @@ const color = tv({
   },
 })
 
+type FollowButtonProps = {
+  pageType: "chef" | "recipe"
+}
+
 /** @package */
-export const ChefFavButton: FC = () => {
+export const FollowButton: FC<FollowButtonProps> = (props) => {
+  const { pageType } = props
   const [isFollow, setIsFollow] = useState<boolean>(false)
 
   const handleClick = () => {
@@ -26,7 +31,13 @@ export const ChefFavButton: FC = () => {
 
   return (
     <button onClick={handleClick} className={color({ isFollow })}>
-      {isFollow ? "フォロー中" : "フォローする"}
+      {pageType === "chef"
+        ? isFollow
+          ? "フォロー中"
+          : "フォローする"
+        : isFollow
+        ? "お気に入りから削除"
+        : "お気に入りに追加"}
     </button>
   )
 }

--- a/frontend/src/app/(app)/chef/[chefId]/_component/index.ts
+++ b/frontend/src/app/(app)/chef/[chefId]/_component/index.ts
@@ -1,2 +1,1 @@
-export { ChefFavButton } from "./ChefFavButton"
-export { BackButton } from "./BackButton"
+export { FollowButton } from "./FollowButton"

--- a/frontend/src/app/(app)/chef/[chefId]/page.tsx
+++ b/frontend/src/app/(app)/chef/[chefId]/page.tsx
@@ -25,9 +25,18 @@ const ChefPage: FC<ChefPageProps> = (props) => {
 
   const linkList = twoTabLinkList(params.chefId)
 
+  const chefData = {
+    follower: 1234,
+    img: "/chef.jpg",
+    introduction:
+      "初の絵本出版！『まねっこシェフ』・ふわふわ！スクランブルエッグ・にぎにぎ！おにぎり主婦の友社より３月３日、２冊同時発売！絶賛発売中！",
+    name: "山田シェフ",
+    recipeCount: 2345,
+  }
+
   return (
     <div>
-      <PageDetailHeader />
+      <PageDetailHeader data={chefData} pageType="chef" />
 
       <div className="py-7">
         <TwoTab linkList={linkList}>

--- a/frontend/src/app/(app)/recipe/[recipeId]/page.tsx
+++ b/frontend/src/app/(app)/recipe/[recipeId]/page.tsx
@@ -1,0 +1,27 @@
+import React, { FC } from "react"
+
+import { PageDetailHeader } from "@/app/(app)/_component/header"
+
+export const metadata = {
+  title: "レシピ詳細",
+}
+
+const ChefPage: FC = () => {
+  const recipeData = {
+    favoriteCount: 222,
+    img: "/pizza.jpg",
+    introduction:
+      "おいしいおいしいマルゲリータピザ。トマトたっぷり・チーズたっぷり！生地はさくさくもっちもち",
+    name: "山田の特性マルゲリータ",
+    user: "山田シェフ",
+    userImg: "/chef.jpg",
+  }
+
+  return (
+    <div>
+      <PageDetailHeader data={recipeData} pageType="recipe" />
+    </div>
+  )
+}
+
+export default ChefPage

--- a/frontend/src/app/(app)/recipe/[recipeId]/page.tsx
+++ b/frontend/src/app/(app)/recipe/[recipeId]/page.tsx
@@ -12,7 +12,7 @@ const ChefPage: FC = () => {
     img: "/pizza.jpg",
     introduction:
       "おいしいおいしいマルゲリータピザ。トマトたっぷり・チーズたっぷり！生地はさくさくもっちもち",
-    name: "山田の特性マルゲリータ",
+    name: "山田の特製マルゲリータ",
     user: "山田シェフ",
     userImg: "/chef.jpg",
   }


### PR DESCRIPTION
## タスク URL

close #54

# 作業内容

- [x] シェフ詳細ヒーローとレシピ詳細ヒーローを共通化
　シェフとレシピのページ.tsxからpropsでヒーロー表示に必要なテキスト・画像情報を渡している
　（まだレスポンス型定義が未定なので渡すデータ型は見直す必要あり）
　型の分岐をconditional typesで表現しているので変な書き方をしていないか・・・？
- [x] お気に入りボタン・フォローボタンの共通化
- [x] 左上戻るボタンの共通化

## 作業内容補足（任意）


## なぜやるのか（任意）


# 使い方や動作確認

## Image

### PC

### SP


# レビューにあたって参考にすべき情報（任意）

## 備考（任意）

