### PR TITLE
SectionHeaderの改修

### DIFF
--- a/frontend/src/app/(app)/_component/header/SectionHeader.test.tsx
+++ b/frontend/src/app/(app)/_component/header/SectionHeader.test.tsx
@@ -3,33 +3,29 @@ import React from "react"
 import { render } from "@testing-library/react"
 
 import { SectionHeader } from "@/app/(app)/_component/header/SectionHeader"
+import { SubButtonLink } from "@/app/(app)/_component/header/SectionHeader.types"
 
 describe("セクションヘッダーが正しくレンダリングされている", () => {
-  test("propsで受け取ったtitleが正しく表示されている", () => {
-    const { getByText } = render(
-      <SectionHeader title="注目のシェフ" href="/favorite" />,
-    )
+  test("propsで受け取ったlabelが正しく表示されている", () => {
+    const { getByText } = render(<SectionHeader label="注目のシェフ" />)
     expect(getByText("注目のシェフ")).toBeInTheDocument()
   })
   // TODO: ページ遷移のテスト
   // test("「もっと見る」をクリックするとpropsで受け取ったhrefのページに遷移する", () => {})
-  describe("propsで受け取ったisMoreの値によって「もっと見る」ボタンの表示が正しく切り替わっている", () => {
-    test("isMoreがtrueのときは「もっと見る」ボタンが表示される", () => {
+  describe("propsで受け取ったsubButtonLinkによってsubButtonLink.labelのボタンの表示・非表示が正しく切り替わっている", () => {
+    test("subButtonLink受け取ったときはsubButtonLinkのlabelのボタンが表示される", () => {
+      const subButtonLink = {
+        href: "/favorite",
+        label: "もっと見る",
+      } as const satisfies SubButtonLink
+
       const { getByText } = render(
-        <SectionHeader title="注目のシェフ" href="/favorite" isMore />,
+        <SectionHeader label="注目のシェフ" subButtonLink={subButtonLink} />,
       )
       expect(getByText("もっと見る")).toBeInTheDocument()
     })
-    test("isMoreがfalseのときは「もっと見る」ボタンが表示されない", () => {
-      const { queryByText } = render(
-        <SectionHeader title="注目のシェフ" href="/favorite" isMore={false} />,
-      )
-      expect(queryByText("もっと見る")).toBeNull()
-    })
-    test("isMoreが指定されていないときはデフォルト値のfalseのため「もっと見る」ボタンが表示されない", () => {
-      const { queryByText } = render(
-        <SectionHeader title="注目のシェフ" href="/favorite" />,
-      )
+    test("subButtonLinkを受け取らなかったときはsubButtonLink.labelのボタンが表示されない", () => {
+      const { queryByText } = render(<SectionHeader label="注目のシェフ" />)
       expect(queryByText("もっと見る")).toBeNull()
     })
   })

--- a/frontend/src/app/(app)/_component/header/SectionHeader.tsx
+++ b/frontend/src/app/(app)/_component/header/SectionHeader.tsx
@@ -1,23 +1,23 @@
 import React, { FC } from "react"
-import { Route } from "next"
 import Link from "next/link"
 
-type SectionHeaderProps<T extends string> = {
-  href: Route<T> | URL
-  isMore?: boolean
-  title: string
+import { SubButtonLink } from "@/app/(app)/_component/header"
+
+type SectionHeaderProps = {
+  label: string
+  subButtonLink?: SubButtonLink
 }
 
 /** @package */
-export const SectionHeader: FC<SectionHeaderProps<string>> = (props) => {
-  const { href, isMore = false, title } = props
+export const SectionHeader: FC<SectionHeaderProps> = (props) => {
+  const { label, subButtonLink } = props
 
   return (
     <div className="flex items-end justify-between font-bold">
-      <h3 className="text-mauve-normal text-xl">{title}</h3>
-      {isMore ? (
+      <h3 className="text-mauve-normal text-xl">{label}</h3>
+      {subButtonLink ? (
         <div className="text-mauve-dim">
-          <Link href={href}>もっと見る</Link>
+          <Link href={subButtonLink.href}>{subButtonLink.label}</Link>
         </div>
       ) : null}
     </div>

--- a/frontend/src/app/(app)/_component/header/SectionHeader.types.ts
+++ b/frontend/src/app/(app)/_component/header/SectionHeader.types.ts
@@ -1,0 +1,7 @@
+import { Route } from "next"
+
+/** @package */
+export type SubButtonLink = {
+  href: Route<string> | URL
+  label: "もっと見る" | "まとめてお買物に追加" | "マイレシピを作成"
+}

--- a/frontend/src/app/(app)/_component/header/index.ts
+++ b/frontend/src/app/(app)/_component/header/index.ts
@@ -1,2 +1,3 @@
 export { SectionHeader } from "./SectionHeader"
 export { PageDetailHeader } from "./PageDetailHeader"
+export { type SubButtonLink } from "./SectionHeader.types"

--- a/frontend/src/app/(app)/search/_component/ChefList.tsx
+++ b/frontend/src/app/(app)/search/_component/ChefList.tsx
@@ -3,7 +3,7 @@ import React from "react"
 import { ScrollAreaWrapper } from "@/app/_component"
 import { ChefCard } from "@/app/(app)/_component/chefCard"
 import { ContentContainer } from "@/app/(app)/_component/container"
-import { SectionHeader } from "@/app/(app)/_component/header"
+import { SectionHeader, SubButtonLink } from "@/app/(app)/_component/header"
 
 /** @package */
 export const ChefList = () => {
@@ -23,10 +23,15 @@ export const ChefList = () => {
     )
   })
 
+  const subButtonLink = {
+    href: "/favorite",
+    label: "もっと見る",
+  } as const satisfies SubButtonLink
+
   return (
     <div className="space-y-4">
       <ContentContainer>
-        <SectionHeader title="シェフ" href="/favorite" isMore />
+        <SectionHeader label="シェフ" subButtonLink={subButtonLink} />
       </ContentContainer>
 
       {/* 横スクロールエリアには右paddingをつけない */}

--- a/frontend/src/app/(app)/search/_component/HotChefList.tsx
+++ b/frontend/src/app/(app)/search/_component/HotChefList.tsx
@@ -16,7 +16,7 @@ export const HotChefList = () => {
   return (
     <div className="space-y-4">
       <ContentContainer>
-        <SectionHeader title="注目のシェフ" href="/favorite" />
+        <SectionHeader label="注目のシェフ" />
       </ContentContainer>
 
       {/* 横スクロールエリアには右paddingをつけない */}

--- a/frontend/src/app/(app)/search/_component/HotRecipeList.tsx
+++ b/frontend/src/app/(app)/search/_component/HotRecipeList.tsx
@@ -2,7 +2,7 @@ import React from "react"
 
 import { ScrollAreaWrapper } from "@/app/_component"
 import { ContentContainer } from "@/app/(app)/_component/container"
-import { SectionHeader } from "@/app/(app)/_component/header"
+import { SectionHeader, SubButtonLink } from "@/app/(app)/_component/header"
 import { RecipeCard } from "@/app/(app)/_component/recipeCard"
 
 /** @package */
@@ -11,10 +11,15 @@ export const HotRecipeList = () => {
     return <RecipeCard key={i} />
   })
 
+  const subButtonLink = {
+    href: "/favorite",
+    label: "もっと見る",
+  } as const satisfies SubButtonLink
+
   return (
     <div className="space-y-4">
       <ContentContainer>
-        <SectionHeader title="話題のレシピ" href="/favorite" isMore />
+        <SectionHeader label="話題のレシピ" subButtonLink={subButtonLink} />
       </ContentContainer>
 
       {/* 横スクロールエリアには右paddingをつけない */}


### PR DESCRIPTION
## タスク URL

#57 
#59 

# 作業内容

- [x] isMoreの値によって「もっと見る」を出し分けていた部分を、subButtonLinkのオブジェクトの有無によって出し分けるように変更
```typescript
const subButtonLink = {
  href: "/favorite",
  label: "もっと見る",
} as const satisfies SubButtonLink

<SectionHeader label="話題のレシピ" subButtonLink={subButtonLink} />

```

## 作業内容補足（任意）

- 作業内容の補足説明があればここに記載

## なぜやるのか（任意）

- セクションヘッダーを「検索タブページ」以外にも、「レシピ詳細ページ」や「お気に入りタブページ」でも共通で使用できるようにするため

# 使い方や動作確認

- 使い方
- 再現手順（どの環境でどんな動作チェックをしたか）
- 動作確認をした事についてスクショなどがあるとわかりやすくて良い

## Image
![スクリーンショット 2023-06-24 15 00 08](https://github.com/qin-team-recipe/05-recipe-app/assets/71167689/890c92af-ee2a-44ea-8db9-dc6e8a514d6b)


### PC


### SP


# レビューにあたって参考にすべき情報（任意）

- 悩んでいること
- とくにレビューしてほしいところ

## 備考（任意）

- その他伝えたいこと
