### PR TITLE
設定ページ・利用規約ページのボトムナビ修正

### DIFF
--- a/frontend/src/app/(app)/_component/bottomNav/BottomNavBar.tsx
+++ b/frontend/src/app/(app)/_component/bottomNav/BottomNavBar.tsx
@@ -30,7 +30,9 @@ export const BottomNavBar: FC<BottomNavBarProps> = (props) => {
   const isShowBottomNav =
     pathname === "/search" ||
     pathname === "/favorite" ||
-    pathname === "/shopping"
+    pathname === "/shopping" ||
+    pathname === "/settings" ||
+    pathname === "/terms"
 
   // TODO: スクロールしている時は非表示にする
   return (

--- a/frontend/src/app/(app)/_component/container/contentContainer.tsx
+++ b/frontend/src/app/(app)/_component/container/contentContainer.tsx
@@ -9,6 +9,7 @@ type ContentContainerProps = {
 }
 
 const container = tv({
+  base: "min-h-screen",
   variants: {
     isPaddingLeft: {
       true: "pl-4",

--- a/frontend/src/app/(app)/_component/container/contentContainer.tsx
+++ b/frontend/src/app/(app)/_component/container/contentContainer.tsx
@@ -9,7 +9,6 @@ type ContentContainerProps = {
 }
 
 const container = tv({
-  base: "min-h-screen",
   variants: {
     isPaddingLeft: {
       true: "pl-4",

--- a/frontend/src/app/(app)/layout.tsx
+++ b/frontend/src/app/(app)/layout.tsx
@@ -26,7 +26,7 @@ export default function MainLayout(props: MainLayoutProps) {
           <BottomNavItem navLabel="お買い物リスト" href="/shopping" />
         </BottomNavBar>
       </nav>
-      <main className="sm:border-x-1 mb-auto mt-0 flex flex-1 flex-col overflow-y-auto sm:border sm:border-y-0 sm:border-solid sm:border-mauve-6">
+      <main className="sm:border-x-1 mb-auto mt-0 flex min-h-screen flex-1 flex-col overflow-y-auto sm:border sm:border-y-0 sm:border-solid sm:border-mauve-6">
         {children}
       </main>
     </div>


### PR DESCRIPTION
## タスク URL

close #106 

# 作業内容

- SPサイズでボトムナビが表示されるように修正
- mainタグにmin-h-screenを追加（要素が少ない時でも両サイドの縦線が下まで表示されるように）

## 作業内容補足（任意）

## なぜやるのか（任意）

# 使い方や動作確認

## Image

### PC

### SP

# レビューにあたって参考にすべき情報（任意）

## 備考（任意）

