### PR TITLE
[マイページ画面]編集ページのフォーム作成

### DIFF
--- a/frontend/src/app/(app)/_component/button/EditButton.tsx
+++ b/frontend/src/app/(app)/_component/button/EditButton.tsx
@@ -24,9 +24,7 @@ export const EditButton: FC<EditButtonProps> = (props) => {
 
   const handleClick = () => {
     if (label === "プロフィールを編集") {
-      // TODO: プロフィールの編集ページへの遷移
-      // router.push("/myPage/edit")
-      router.push("/search")
+      router.push("/myPage/edit")
     } else {
       // TODO: レシピの編集ページへの遷移
       // router.push("/recipe/edit")

--- a/frontend/src/app/(app)/_component/button/UpdateButton.tsx
+++ b/frontend/src/app/(app)/_component/button/UpdateButton.tsx
@@ -1,0 +1,24 @@
+import React, { ButtonHTMLAttributes, FC, ReactNode } from "react"
+
+import { tv } from "tailwind-variants"
+
+type UpdateButtonProps = ButtonHTMLAttributes<HTMLButtonElement> & {
+  children: ReactNode
+  isSave?: boolean
+}
+const updateButton = tv({
+  base: "w-full px-3 py-2 border pointer rounded",
+  variants: {
+    isSave: {
+      false:
+        "border-tomato-7 text-tomato-11 bg-tomato-1 hover:bg-tomato-2 active:bg-tomato-3",
+      true: "bg-tomato-solid border-tomato-10 text-tomato-1 active:bg-tomato-11 dark:border-tomato-9",
+    },
+  },
+})
+
+/** @package */
+export const UpdateButton: FC<UpdateButtonProps> = (props) => {
+  const { children, isSave = false } = props
+  return <button className={updateButton({ isSave })}>{children}</button>
+}

--- a/frontend/src/app/(app)/_component/button/index.ts
+++ b/frontend/src/app/(app)/_component/button/index.ts
@@ -1,3 +1,4 @@
 export { baseActionButton } from "./baseButton"
 export { FollowButton } from "./FollowButton"
 export { EditButton } from "./EditButton"
+export { UpdateButton } from "./UpdateButton"

--- a/frontend/src/app/(app)/_component/formElements/InputCommon.tsx
+++ b/frontend/src/app/(app)/_component/formElements/InputCommon.tsx
@@ -1,0 +1,72 @@
+import React, { ChangeEvent, FC, useState } from "react"
+
+import { BiPlus } from "react-icons/bi"
+
+/** 共通入力フォームのprops */
+type InputCommonProps = {
+  isRequired?: boolean
+  name: string
+  placeholder?: string
+  title: string
+  type: "text" | "image"
+}
+/** 共通入力フォーム */
+/** @package */
+export const InputCommon: FC<InputCommonProps> = (props) => {
+  const { isRequired, name, placeholder, title, type } = props
+  const [text, setText] = useState("")
+  const [selectedFile, setSelectedFile] = useState<File | null>(null)
+
+  const handleFileChange = (event: ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0]
+    setSelectedFile(file || null)
+  }
+
+  const textInput = (
+    <div className="flex flex-col gap-1">
+      <label className="px-4 text-base font-bold leading-5">
+        {title}
+        {isRequired ?? "（任意）"}
+      </label>
+      <input
+        name={name}
+        type="text"
+        value={text}
+        onChange={(e) => {
+          setText(e.target.value)
+        }}
+        className="w-full border-y border-mauve-7 px-4 py-3"
+        placeholder={placeholder ? placeholder : ""}
+        required={isRequired}
+      />
+    </div>
+  )
+
+  const imageInput = (
+    <div className="flex flex-col gap-1 px-4">
+      <h2 className="text-base font-bold leading-5">
+        {title}
+        {isRequired ?? "（任意）"}
+      </h2>
+      <label className="flex h-24 w-24 cursor-pointer flex-col items-center justify-center rounded-lg border border-mauve-6 bg-mauve-1 text-mauve-11">
+        <span className="font-inter text-xs font-normal">画像を設定</span>
+        <span className="text-gray-400 text-2xl">
+          <BiPlus />
+        </span>
+        <input
+          name={name}
+          type="file"
+          className="hidden"
+          onChange={handleFileChange}
+        />
+      </label>
+    </div>
+  )
+
+  switch (type) {
+    case "text":
+      return textInput
+    case "image":
+      return imageInput
+  }
+}

--- a/frontend/src/app/(app)/_component/formElements/InputCommon.tsx
+++ b/frontend/src/app/(app)/_component/formElements/InputCommon.tsx
@@ -13,7 +13,7 @@ type InputCommonProps = {
 /** 共通入力フォーム */
 /** @package */
 export const InputCommon: FC<InputCommonProps> = (props) => {
-  const { isRequired, name, placeholder, title, type } = props
+  const { isRequired = false, name, placeholder, title, type } = props
   const [text, setText] = useState("")
   const [selectedFile, setSelectedFile] = useState<File | null>(null)
 
@@ -26,7 +26,7 @@ export const InputCommon: FC<InputCommonProps> = (props) => {
     <div className="flex flex-col gap-1">
       <label className="px-4 text-base font-bold leading-5">
         {title}
-        {isRequired ?? "（任意）"}
+        {isRequired ? "" : "（任意）"}
       </label>
       <input
         name={name}
@@ -46,7 +46,7 @@ export const InputCommon: FC<InputCommonProps> = (props) => {
     <div className="flex flex-col gap-1 px-4">
       <h2 className="text-base font-bold leading-5">
         {title}
-        {isRequired ?? "（任意）"}
+        {isRequired ? "" : "（任意）"}
       </h2>
       <label className="flex h-24 w-24 cursor-pointer flex-col items-center justify-center rounded-lg border border-mauve-6 bg-mauve-1 text-mauve-11">
         <span className="font-inter text-xs font-normal">画像を設定</span>
@@ -58,6 +58,7 @@ export const InputCommon: FC<InputCommonProps> = (props) => {
           type="file"
           className="hidden"
           onChange={handleFileChange}
+          required={isRequired}
         />
       </label>
     </div>

--- a/frontend/src/app/(app)/_component/formElements/TextAreaCommon.tsx
+++ b/frontend/src/app/(app)/_component/formElements/TextAreaCommon.tsx
@@ -1,0 +1,30 @@
+"use client"
+
+import React, { FC, useState } from "react"
+
+type TextAreaCommonProps = {
+  isRequired?: boolean
+  name: string
+  title: string
+}
+
+export const TextAreaCommon: FC<TextAreaCommonProps> = (props) => {
+  const { isRequired, name, title } = props
+  const [text, setText] = useState("")
+  return (
+    <div className="flex flex-col gap-1">
+      <label className="px-4 text-base font-bold leading-5">
+        {title}
+        {isRequired ?? "（任意）"}
+      </label>
+      <textarea
+        className="form-input h-[4.5rem] w-full border-y border-mauve-7 px-4 py-3"
+        name={name}
+        value={text}
+        onChange={(e) => {
+          setText(e.target.value)
+        }}
+      />
+    </div>
+  )
+}

--- a/frontend/src/app/(app)/_component/formElements/TextAreaCommon.tsx
+++ b/frontend/src/app/(app)/_component/formElements/TextAreaCommon.tsx
@@ -9,17 +9,18 @@ type TextAreaCommonProps = {
 }
 
 export const TextAreaCommon: FC<TextAreaCommonProps> = (props) => {
-  const { isRequired, name, title } = props
+  const { isRequired = false, name, title } = props
   const [text, setText] = useState("")
   return (
     <div className="flex flex-col gap-1">
       <label className="px-4 text-base font-bold leading-5">
         {title}
-        {isRequired ?? "（任意）"}
+        {isRequired ? "" : "（任意）"}
       </label>
       <textarea
         className="form-input h-[4.5rem] w-full border-y border-mauve-7 px-4 py-3"
         name={name}
+        required={isRequired}
         value={text}
         onChange={(e) => {
           setText(e.target.value)

--- a/frontend/src/app/(app)/_component/formElements/index.ts
+++ b/frontend/src/app/(app)/_component/formElements/index.ts
@@ -1,0 +1,2 @@
+export { InputCommon } from "./InputCommon"
+export { TextAreaCommon } from "./TextAreaCommon"

--- a/frontend/src/app/(app)/_component/recipeItem/LinkListItem.tsx
+++ b/frontend/src/app/(app)/_component/recipeItem/LinkListItem.tsx
@@ -1,0 +1,30 @@
+"use client"
+
+import React, { FC, useState } from "react"
+
+import { tv } from "tailwind-variants"
+
+import { baseRecipeItem } from "@/app/(app)/_component/recipeItem/baseRecipeItem"
+
+type LinkListProps = {
+  preUrl?: string
+}
+const linkListItem = tv({
+  extend: baseRecipeItem,
+})
+
+export const LinkListItem: FC<LinkListProps> = (props) => {
+  const { preUrl } = props
+  const [url, setUrl] = useState(preUrl ?? "")
+
+  return (
+    <input
+      className={linkListItem()}
+      value={url}
+      type="text"
+      onChange={(e) => {
+        return setUrl(e.target.value)
+      }}
+    />
+  )
+}

--- a/frontend/src/app/(app)/_component/recipeItem/baseRecipeItem.ts
+++ b/frontend/src/app/(app)/_component/recipeItem/baseRecipeItem.ts
@@ -1,0 +1,6 @@
+import { tv } from "tailwind-variants"
+
+/** @package */
+export const baseRecipeItem = tv({
+  base: "w-full border-b border-b-mauve-7 px-2 py-4 text-mauve-12",
+})

--- a/frontend/src/app/(app)/_component/recipeItem/index.ts
+++ b/frontend/src/app/(app)/_component/recipeItem/index.ts
@@ -1,1 +1,2 @@
 export { RecipeItem } from "./RecipeItem"
+export { LinkListItem } from "./LinkListItem"

--- a/frontend/src/app/(app)/myPage/edit/_component/LinkList.tsx
+++ b/frontend/src/app/(app)/myPage/edit/_component/LinkList.tsx
@@ -1,4 +1,4 @@
-import React from "react"
+import React, { FC } from "react"
 
 import { BiPlus } from "react-icons/bi"
 
@@ -6,28 +6,40 @@ import { LinkListItem } from "@/app/(app)/_component/recipeItem"
 
 const dummyUrl = ["https://twitter.com/home", "https://www.instagram.com/"]
 
+type LinkListProps = {
+  isRequired?: boolean
+  title: string
+}
+
 //TODO: fetchしたデータと追加するデータのマージ処理方法を検討
 /** @package */
-export const LinkList = () => {
+export const LinkList: FC<LinkListProps> = (props) => {
+  const { isRequired, title } = props
   return (
-    <div className="border-t border-t-mauve-7">
-      <ul>
-        {dummyUrl.map((url) => {
-          return (
-            <li key={url}>
-              <LinkListItem preUrl={url} />
-            </li>
-          )
-        })}
-      </ul>
-      <div className="px-4 pt-2">
-        <button
-          className="flex items-center gap-1 border-none text-tomato-9 outline-none"
-          type="button"
-        >
-          <BiPlus />
-          <span>リンクを追加する</span>
-        </button>
+    <div className="flex flex-col gap-1">
+      <label className="px-4 text-base font-bold leading-5">
+        {title}
+        {isRequired ?? "（任意）"}
+      </label>
+      <div className="border-t border-t-mauve-7">
+        <ul>
+          {dummyUrl.map((url) => {
+            return (
+              <li key={url}>
+                <LinkListItem preUrl={url} />
+              </li>
+            )
+          })}
+        </ul>
+        <div className="px-4 pt-2">
+          <button
+            className="flex items-center gap-1 border-none text-tomato-9 outline-none"
+            type="button"
+          >
+            <BiPlus />
+            <span>リンクを追加する</span>
+          </button>
+        </div>
       </div>
     </div>
   )

--- a/frontend/src/app/(app)/myPage/edit/_component/LinkList.tsx
+++ b/frontend/src/app/(app)/myPage/edit/_component/LinkList.tsx
@@ -1,0 +1,34 @@
+import React from "react"
+
+import { BiPlus } from "react-icons/bi"
+
+import { LinkListItem } from "@/app/(app)/_component/recipeItem"
+
+const dummyUrl = ["https://twitter.com/home", "https://www.instagram.com/"]
+
+//TODO: fetchしたデータと追加するデータのマージ処理方法を検討
+/** @package */
+export const LinkList = () => {
+  return (
+    <div className="border-t border-t-mauve-7">
+      <ul>
+        {dummyUrl.map((url) => {
+          return (
+            <li key={url}>
+              <LinkListItem preUrl={url} />
+            </li>
+          )
+        })}
+      </ul>
+      <div className="px-4 pt-2">
+        <button
+          className="flex items-center gap-1 border-none text-tomato-9 outline-none"
+          type="button"
+        >
+          <BiPlus />
+          <span>リンクを追加する</span>
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/app/(app)/myPage/edit/_component/ProfileEditForm.tsx
+++ b/frontend/src/app/(app)/myPage/edit/_component/ProfileEditForm.tsx
@@ -35,7 +35,7 @@ export const ProfileEditForm: FC = () => {
         name="profileImage"
       />
       <TextAreaCommon name="introduntion" title="自己紹介" />
-      <LinkList />
+      <LinkList title="リンク" />
 
       <div className="flex items-center justify-center gap-4 px-4">
         <UpdateButton isSave>登録する</UpdateButton>

--- a/frontend/src/app/(app)/myPage/edit/_component/ProfileEditForm.tsx
+++ b/frontend/src/app/(app)/myPage/edit/_component/ProfileEditForm.tsx
@@ -33,8 +33,9 @@ export const ProfileEditForm: FC = () => {
         title="プロフィール画像"
         type="image"
         name="profileImage"
+        isRequired
       />
-      <TextAreaCommon name="introduntion" title="自己紹介" />
+      <TextAreaCommon isRequired name="introduntion" title="自己紹介" />
       <LinkList title="リンク" />
 
       <div className="flex items-center justify-center gap-4 px-4">

--- a/frontend/src/app/(app)/myPage/edit/_component/ProfileEditForm.tsx
+++ b/frontend/src/app/(app)/myPage/edit/_component/ProfileEditForm.tsx
@@ -1,0 +1,46 @@
+"use client"
+
+import React, { FC } from "react"
+import { useRouter } from "next/navigation"
+
+import { UpdateButton } from "@/app/(app)/_component/button"
+import {
+  InputCommon,
+  TextAreaCommon,
+} from "@/app/(app)/_component/formElements"
+import { LinkList } from "@/app/(app)/myPage/edit/_component/LinkList"
+
+/** @package*/
+export const ProfileEditForm: FC = () => {
+  const router = useRouter()
+  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault()
+    router.push("/myPage")
+  }
+  return (
+    <form
+      className="flex h-full  w-full flex-col gap-8 pt-5"
+      onSubmit={handleSubmit}
+    >
+      <InputCommon
+        name="nickname"
+        title="ニックネーム"
+        type="text"
+        isRequired
+      />
+      <InputCommon
+        placeholder="画像を選択"
+        title="プロフィール画像"
+        type="image"
+        name="profileImage"
+      />
+      <TextAreaCommon name="introduntion" title="自己紹介" />
+      <LinkList />
+
+      <div className="flex items-center justify-center gap-4 px-4">
+        <UpdateButton isSave>登録する</UpdateButton>
+        <UpdateButton>キャンセル</UpdateButton>
+      </div>
+    </form>
+  )
+}

--- a/frontend/src/app/(app)/myPage/edit/_component/index.ts
+++ b/frontend/src/app/(app)/myPage/edit/_component/index.ts
@@ -1,0 +1,1 @@
+export { ProfileEditForm } from "./ProfileEditForm"

--- a/frontend/src/app/(app)/myPage/edit/page.tsx
+++ b/frontend/src/app/(app)/myPage/edit/page.tsx
@@ -1,0 +1,18 @@
+import React, { FC } from "react"
+
+import { PageHeader } from "@/app/(app)/_component/header"
+import { ProfileEditForm } from "@/app/(app)/myPage/edit/_component"
+
+export const metadata = {
+  title: "プロフィール編集｜マイページ",
+}
+
+const ProfileEditPage: FC = () => {
+  return (
+    <div className="h-screen bg-mauve-3">
+      <PageHeader title="編集" titleAlign="center" />
+      <ProfileEditForm />
+    </div>
+  )
+}
+export default ProfileEditPage


### PR DESCRIPTION
## タスク URL
[#109 ](https://github.com/qin-team-recipe/05-recipe-app/issues/109)

# 作業内容

- [x] マイページ編集ページのレイアウト
- [x] フォーム要素の共通コンポーネントを作成
- [x] 保存・キャンセルボタンの共通コンポーネント 


## 作業内容補足（任意）

- レイアウトだけになっているので、機能追加として別途タスクが切られています。
- リンクリストはハードコーディングしています。まだ追加機能はありません。

## なぜやるのか（任意）
-
# 使い方や動作確認

- http://localhost:3000/myPageからプロフィール編集ボタンを押下

### SP
<img width="312" alt="image" src="https://github.com/qin-team-recipe/05-recipe-app/assets/67671210/02ab63c4-4289-4f5b-b29a-a980b2cb7047">
<img width="313" alt="image" src="https://github.com/qin-team-recipe/05-recipe-app/assets/67671210/94cfc362-d8d1-4f9f-8cd4-3c596ef58dea">


# レビューにあたって参考にすべき情報（任意）

- リンクリストの配列をどうやってAPIに渡そうか悩んでいます（機能実装時に考えようと思っています。）機能実装時にコンポーネントの構成を修正するかもです。

## 備考（任意）

- その他伝えたいこと
